### PR TITLE
Load subr-x for using its function

### DIFF
--- a/find-dupes-dired.el
+++ b/find-dupes-dired.el
@@ -37,6 +37,7 @@
 
 (eval-when-compile (require 'cl-lib))
 (require 'find-dired)
+(require 'subr-x)
 
 (defgroup find-dupes-dired nil
   "Run a `find-dupes-dired' command and Dired the output."


### PR DESCRIPTION
This fixes a following byte-compile warning.

```
find-dupes-dired.el:461:1:Warning: the function ‘string-blank-p’ is not known
    to be defined.
```